### PR TITLE
Update to use apt command instead of yum for MSGGW deployment

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,10 +12,10 @@ runs:
         #However, the $HOME folder is changed to /github/home
         #TODO: elixir dependencies migration
         echo $(whoami)
-        # apt-get update -y
-        # apt-get install sudo jq -y
-        yum update -y
-        yum install sudo tar jq -y
+        apt-get update -y
+        apt-get install sudo jq -y
+        # yum update -y
+        # yum install sudo tar jq -y
         sudo rm -f $HOME/.ssh/config
         sudo cp -a /root/. $HOME/
       shell: bash


### PR DESCRIPTION
The runner for the MSSGW pipeline runs  on Ubuntu, so we need to use apt command instead of yum 